### PR TITLE
golang 1.11.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 
 go:
   - "1.x"
-  - "1.11.4"
+  - "1.11.5"
 
 env:
   - GO111MODULE=on

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.11.2
+ARG GO_VERSION=1.11.5
 FROM golang:${GO_VERSION}-alpine as builder
 
 # Note: make sure to sync any dependencies added here to the "make test" step in the Jenkinsfile.


### PR DESCRIPTION
# What and why?

https://github.com/golang/go/issues/29903 / CVE-2019-6486

Bump builds up to 1.11.5

# Testing Steps

Wait for travis to build :)

# Reviewers

Required reviewers: @newfurniturey @defect @komapa 
Request reviews from other people you want to review this PR in the "Reviewers" section on the right.

> :warning: this PR must have at least 2 thumbs from the [MAINTAINERS.md](/MAINTAINERS.md) of the project before merging!
